### PR TITLE
Added support for pulling custom user fields

### DIFF
--- a/javascripts/discourse/initializers/init-discourse-reply-template-component.js.es6
+++ b/javascripts/discourse/initializers/init-discourse-reply-template-component.js.es6
@@ -184,6 +184,22 @@ function openComposerWithTemplateAndAction(controller, post, wrap) {
         },
       },
       {
+        regex: /\$user_field_(\d+)/g,
+        fn: (m) => {
+          const matchPart = m.match(/\$user_field_(\d+)/);
+
+          if (matchPart) {
+            const numberPart = parseInt(matchPart[1]); // Extract the number part from the matched pattern
+
+            // Check if the field exists before accessing it to avoid errors
+            if (currentUser.custom_fields.hasOwnProperty(`user_field_${numberPart}`)) {
+              return currentUser.custom_fields[`user_field_${numberPart}`];
+            }
+          }
+          return "";
+        },
+      },
+      {
         regex: /\=([A-Z]*)\=/g,
         fn: (m) => {
           // match any placeholder values set up via discourse-placeholder-theme-component


### PR DESCRIPTION
This will allow you to pull the content of a user's custom user field, assuming you already figured out it's internal id.

The code checks if the user field exists before returning it.

syntax: $user_field_number