### PR TITLE
DEV: Show login from application route

### DIFF
--- a/javascripts/discourse/initializers/init-discourse-reply-template-component.js
+++ b/javascripts/discourse/initializers/init-discourse-reply-template-component.js
@@ -3,7 +3,6 @@ import { escape } from "pretty-text/sanitizer";
 import { ajax } from "discourse/lib/ajax";
 import { getOwnerWithFallback } from "discourse/lib/get-owner";
 import { withPluginApi } from "discourse/lib/plugin-api";
-import showModal from "discourse/lib/show-modal";
 import { emojiUnescape } from "discourse/lib/text";
 import Composer from "discourse/models/composer";
 import { i18n } from "discourse-i18n";
@@ -104,9 +103,10 @@ function _buildDraftKey(topicId, action) {
 }
 
 function openComposerWithTemplateAndAction(controller, post, wrap) {
-  const currentUser = getOwnerWithFallback(this).lookup("service:current-user");
+  const owner = getOwnerWithFallback(this);
+  const currentUser = owner.lookup("service:current-user");
   if (!currentUser) {
-    showModal("login");
+    owner.lookup("route:application").send("showLogin");
     return;
   }
 


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/reply-template/162373/60?u=arkshine

This PR relies on the application route `showLogin` action instead of the deprecated controller-based `showModal("login")`.

Before:
![image](https://github.com/user-attachments/assets/82e75949-ffaf-4e66-a7dc-86f8daa67c21)

After:

![chrome_9CBpy21BJ9](https://github.com/user-attachments/assets/5a789a1d-affe-4221-9c39-156f2f3708a9)
