### PR TITLE
UX: Remove conflicting btn class

### DIFF
--- a/javascripts/discourse/initializers/init-discourse-reply-template-component.js
+++ b/javascripts/discourse/initializers/init-discourse-reply-template-component.js
@@ -13,7 +13,7 @@ function buildButton(dataset, extraClass) {
   const label = dataset.label;
 
   const button = document.createElement("button");
-  button.classList.add("add-template", "btn", "btn-default", "btn-primary");
+  button.classList.add("add-template", "btn", "btn-primary");
 
   if (extraClass) {
     button.classList.add(extraClass);


### PR DESCRIPTION
AFAIK a button should never be both `default` and `primary`. For templates, using `primary` seems correct.